### PR TITLE
Feature/PLA-662 fixup bootscript logic

### DIFF
--- a/core/cloudcoreo_agent.py
+++ b/core/cloudcoreo_agent.py
@@ -393,7 +393,9 @@ def bootstrap():
     clone_for_asi(asi['branch'], asi['revision'], appstack['gitUrl'], key['keyMaterial'],
                   OPTIONS_FROM_CONFIG_FILE.work_dir)
     #  run_all_boot_scripts("#{DaemonKit.arguments.options[:work_dir]}", "#{DaemonKit.arguments.options[:server_name]}")
-    run_all_boot_scripts(OPTIONS_FROM_CONFIG_FILE.work_dir, OPTIONS_FROM_CONFIG_FILE.serverName)
+    if OPTIONS_FROM_CONFIG_FILE.server_name and len(OPTIONS_FROM_CONFIG_FILE.server_name):
+        repo_dir = OPTIONS_FROM_CONFIG_FILE.work_dir + '/repo'
+        run_all_boot_scripts(repo_dir, OPTIONS_FROM_CONFIG_FILE.server_name)
 
 
 def send_logs_to_webapp():

--- a/core/cloudcoreo_agent.py
+++ b/core/cloudcoreo_agent.py
@@ -293,11 +293,13 @@ def get_script_order_files(root_dir, server_name):
             strings_replaced = string.replace(
                 string.replace(string.replace(full_path.lower(), "extends", ""), "#{server_name.downcase}", ""), "/",
                 "")
-            log("checking if boot-scritsorder is in [%s]" % strings_replaced)
+            log("checking if boot-scriptsorder is in [%s]" % strings_replaced)
             if "boot-scriptsorder" in strings_replaced:
                 order_files.append(full_path)
-    if len(order_files) == 0 and server_name != "repo":
-        order_files = get_script_order_files(root_dir, "repo")
+    # DM: 08Aug2016: this logic seems wrong
+    # TODO:
+    # if len(order_files) == 0 and server_name != "repo":
+    #     order_files = get_script_order_files(root_dir, "repo")
     log("found ordered_files: %s" % order_files)
     order_files.sort(key=len, reverse=True)
     log("order_files %s" % order_files)


### PR DESCRIPTION
Let's look for boot scripts within the repo directory.
We only want to run scripts that are for "server_name", therefore recursion using "repo" is unnecessary.